### PR TITLE
use provided color instead of scale

### DIFF
--- a/inst/htmlwidgets/d3wordcloud.js
+++ b/inst/htmlwidgets/d3wordcloud.js
@@ -137,7 +137,14 @@ HTMLWidgets.widget({
         .style("font-size", function(d) { return d.size + "px"; });
 
       text.style("font-family", x.pars.font)
-        .style("fill", function(d) { return colorscale(d.size); })
+        .style("fill", function(d) {
+           if (x.pars.every_word_has_own_color) {
+             return d.color;
+           } else {
+           return colorscale(d.size);
+           }
+           })
+
         .attr("data-toggle", "tooltip")
         .text(function(d) { return d.text; });
 


### PR DESCRIPTION
Hi Joshua, 
I was having trouble with the colors whenever I provided a color for each word if the word freq was the same for two or more words. It traced back to the behavior of d3.scale.ordinal() line 78. The change I have made is just to check for every_word_has_own_color and use the d.color if it is present. 

This solves my problem but does not necessarily behave in the way you want it to but please have a look. 

Matt
