### PR TITLE
tooltip label should now be optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Date: 2015-05-09
 Authors@R: c(
     person("Joshua", "Kunst", email = "jbkunst@gmail.com",
     role = c("aut", "cre")),
-    person("Charles", "Sese", role = "ctb")
+    person("Charles", "Sese", role = "ctb"),
+    person("Matthew", "Johnson", role = "ctb")
     )
 Description: d3wordcloud is a R package for create D3 JavaScript wordcloud via
     htmlwidgets for D3js Word Cloud Layout.

--- a/R/d3wordcloud.R
+++ b/R/d3wordcloud.R
@@ -109,10 +109,6 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
             size.scale %in% c("log", "sqrt", "linear"),
             color.scale %in% c("log", "sqrt", "linear"),
             spiral %in% c("archimedean", "rectangular"))
-
-  if (!is.null(label)) {
-    stopifnot(length(words) == length(label))
-  }
   
   missing_colors <- missing(colors)
 
@@ -123,9 +119,13 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
 
   data <- data.frame(text = as.character(words),
                      freq = as.numeric(freqs),
-                     size = as.numeric(freqs), 
-                     label = as.character(label), stringsAsFactors = FALSE)
+                     size = as.numeric(freqs), stringsAsFactors = FALSE)
 
+  if (!is.null(label)) {
+    stopifnot(length(words) == length(label))
+    data$label = label
+  }
+  
   every_word_has_own_color <- length(colors) == length(words)
 
   if (every_word_has_own_color) {

--- a/R/d3wordcloud.R
+++ b/R/d3wordcloud.R
@@ -109,7 +109,7 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
             size.scale %in% c("log", "sqrt", "linear"),
             color.scale %in% c("log", "sqrt", "linear"),
             spiral %in% c("archimedean", "rectangular"))
-  
+
   missing_colors <- missing(colors)
 
   if (!missing_colors) {
@@ -125,7 +125,7 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
     stopifnot(length(words) == length(label))
     data$label = label
   }
-  
+
   every_word_has_own_color <- length(colors) == length(words)
 
   if (every_word_has_own_color) {
@@ -148,7 +148,8 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
                       spiral = spiral,
                       colors = colors,
                       every_word_has_own_color = every_word_has_own_color,
-                      missing_colors = missing_colors)
+                      missing_colors = missing_colors,
+                      label = label)
   )
 
   # create widget

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ There are parameter for make your word cloud like you like/want:
 -   `rotate.max`: Maximum angle for (random) rotation. Default value is
     `30`.
 -   `tooltip`: Do you want tooltips showing the frequecny on cursor hover? ;)
+-   `label`: Alternate text for tooltip to display.
 -   `rangesizefont` A 2 length numeric vector indicating the size of text (this is usefull if you have sentences instead of words).
 
 You can see this parameter in action here

--- a/inst/htmlwidgets/d3wordcloud.js
+++ b/inst/htmlwidgets/d3wordcloud.js
@@ -180,7 +180,8 @@ HTMLWidgets.widget({
           text
             .on("mouseover", mouseover)
             .on("mouseout", mouseout)
-            .on("mousemove", mousemove);
+            .on("mousemove", mousemove)
+			.on("mousedown", mousedown);
 
           function mouseover(d){
             tooltip.transition().duration(100).style("opacity", 1);
@@ -201,6 +202,10 @@ HTMLWidgets.widget({
               .style("top", (d3.event.pageY + - 70) + "px");
 
           }
+		  function mousedown(d){
+              window.open(d.text + '.html', "_blank");
+          }
+
 
       }
 

--- a/inst/htmlwidgets/d3wordcloud.js
+++ b/inst/htmlwidgets/d3wordcloud.js
@@ -137,7 +137,14 @@ HTMLWidgets.widget({
         .style("font-size", function(d) { return d.size + "px"; });
 
       text.style("font-family", x.pars.font)
-        .style("fill", function(d) { return colorscale(d.size); })
+        .style("fill", function(d) {
+           if (x.pars.every_word_has_own_color) {
+             return d.color;
+           } else {
+           return colorscale(d.size);
+           }
+           })
+
         .attr("data-toggle", "tooltip")
         .text(function(d) { return d.text; });
 

--- a/inst/htmlwidgets/d3wordcloud.js
+++ b/inst/htmlwidgets/d3wordcloud.js
@@ -187,8 +187,8 @@ HTMLWidgets.widget({
           text
             .on("mouseover", mouseover)
             .on("mouseout", mouseout)
-            .on("mousemove", mousemove)
-			.on("mousedown", mousedown);
+			//.on("mousedown", mousedown)
+            .on("mousemove", mousemove);
 
           function mouseover(d){
             tooltip.transition().duration(100).style("opacity", 1);
@@ -209,9 +209,9 @@ HTMLWidgets.widget({
               .style("top", (d3.event.pageY + - 70) + "px");
 
           }
-		  function mousedown(d){
-              window.open(d.text + '.html', "_blank");
-          }
+		  //function mousedown(d){
+          //    window.open(d.text + '.html', "_blank");
+          //}
 
 
       }

--- a/inst/htmlwidgets/d3wordcloud.js
+++ b/inst/htmlwidgets/d3wordcloud.js
@@ -192,7 +192,7 @@ HTMLWidgets.widget({
 
           function mouseover(d){
             tooltip.transition().duration(100).style("opacity", 1);
-            txt = (d.label === null) ? d.text + ": " + d.freq: d.label + ": " + d.freq;
+            txt = (x.pars.label === null) ? d.text + ": " + d.freq: d.label + ": " + d.freq;
             console.log(d);
             tooltip.html(txt);
 

--- a/man/d3wordcloud.Rd
+++ b/man/d3wordcloud.Rd
@@ -7,7 +7,7 @@
 d3wordcloud(words, freqs, colors = NULL, font = "Open Sans", padding = 1,
   rotate.min = -30, rotate.max = 30, size.scale = "linear",
   color.scale = "linear", spiral = "archimedean", tooltip = FALSE,
-  rangesizefont = c(10, 90), width = NULL, height = NULL)
+  label = NULL, rangesizefont = c(10, 90), width = NULL, height = NULL)
 }
 \arguments{
 \item{words}{The words}
@@ -36,6 +36,8 @@ is generated (the order is important here).}
 `archimedean` and `rectangular`. Default value is `archimedean`.}
 
 \item{tooltip}{Boolean indicating if the cursor is over the text show a tooltip with the size}
+
+\item{label}{character vector of alternate text to use in tooltips (must match length of unique words).}
 
 \item{rangesizefont}{A 2 length numeric vector indicating the size of text.}
 

--- a/patch1.diff
+++ b/patch1.diff
@@ -1,0 +1,59 @@
+From 03bc64de7ab99e145b9c5a8dfd6dc35e4457b23d Mon Sep 17 00:00:00 2001
+From: unknown <johnsom@ep027072.int.epa.vic.gov.au>
+Date: Wed, 27 Apr 2016 08:08:46 +1000
+Subject: [PATCH] added label to x.pars.label and added x.pars.label to tooltip
+ mouseover
+
+---
+ R/d3wordcloud.R                 | 7 ++++---
+ inst/htmlwidgets/d3wordcloud.js | 2 +-
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/R/d3wordcloud.R b/R/d3wordcloud.R
+index a1e1380..ada7c2f 100644
+--- a/R/d3wordcloud.R
++++ b/R/d3wordcloud.R
+@@ -109,7 +109,7 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
+             size.scale %in% c("log", "sqrt", "linear"),
+             color.scale %in% c("log", "sqrt", "linear"),
+             spiral %in% c("archimedean", "rectangular"))
+-  
++
+   missing_colors <- missing(colors)
+ 
+   if (!missing_colors) {
+@@ -125,7 +125,7 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
+     stopifnot(length(words) == length(label))
+     data$label = label
+   }
+-  
++
+   every_word_has_own_color <- length(colors) == length(words)
+ 
+   if (every_word_has_own_color) {
+@@ -148,7 +148,8 @@ d3wordcloud <- function(words, freqs, colors = NULL, font = "Open Sans",
+                       spiral = spiral,
+                       colors = colors,
+                       every_word_has_own_color = every_word_has_own_color,
+-                      missing_colors = missing_colors)
++                      missing_colors = missing_colors,
++                      label = label)
+   )
+ 
+   # create widget
+diff --git a/inst/htmlwidgets/d3wordcloud.js b/inst/htmlwidgets/d3wordcloud.js
+index dd5abf3..ee637e6 100644
+--- a/inst/htmlwidgets/d3wordcloud.js
++++ b/inst/htmlwidgets/d3wordcloud.js
+@@ -192,7 +192,7 @@ HTMLWidgets.widget({
+ 
+           function mouseover(d){
+             tooltip.transition().duration(100).style("opacity", 1);
+-            txt = (d.label === null) ? d.text + ": " + d.freq: d.label + ": " + d.freq;
++            txt = (x.pars.label === null) ? d.text + ": " + d.freq: d.label + ": " + d.freq;
+             console.log(d);
+             tooltip.html(txt);
+ 
+-- 
+2.6.1.windows.1
+


### PR DESCRIPTION
Hi Joshua, 
I hope this pull request is not too confusing. I am new to github and have a lot to learn. 

The purpose of this pull request is to change the way the tooltip label works. As it was everything would break if a character vector of labels was not included. 

I have also been working on a "mousedown" function that opens a url in the format word.html. This works well  for my usage but I feel is currently a bit limited so it is commented out. 

sorry for the confusion, 

Matt  
