### PR TITLE
first attempt to change to allow resize and avoid infinite loop

### DIFF
--- a/inst/htmlwidgets/d3wordcloud.js
+++ b/inst/htmlwidgets/d3wordcloud.js
@@ -165,7 +165,7 @@ HTMLWidgets.widget({
         .attr("transform", "translate(" + [w >> 1, h >> 1] + ")scale(" + 1 + ")");
 
       if(x.pars.tooltip) {
-          var tooltip = d3.select(el).select('.d3wordcloud-tooltip').data([0]);
+          var tooltip = d3.select(el).selectAll('.d3wordcloud-tooltip').data([0]);
 
           tooltip.enter()
             .append("div")
@@ -199,7 +199,7 @@ HTMLWidgets.widget({
 
           function mouseout(d){
             tooltip.transition().duration(100).style("opacity", 0);
-            d3.select("#" + idcontainer).selectAll("text").transition().duration(100).style("opacity", 1);
+            d3.select(el).selectAll("text").transition().duration(100).style("opacity", 1);
 
           }
           function mousemove(d){


### PR DESCRIPTION
This can certainly be refined and improved, but for now this pull seeks to address #19.

**Summary of Changes**
- create new `drawWordCloud` method for use by `render` and `resize`
- bail out of word cloud instantiation if either width or height are 0 to avoid infinite loop
- add `resize` call
- change `append` to `data([0]).enter().append()` pattern for reused elements like `tooltip`
- add `instance.drawn` to avoid adding font multiple times; note, if more than one `d3wordcloud` in document, multiple same `css` will be added but not really a problem since cached
